### PR TITLE
fix: only filters or backends can be started by compatible-ctl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cups (2.4.2-5deepin3) unstable; urgency=medium
+
+  * Fix bug
+
+ -- LIU Li <liuli@uniontech.com>  Fri, 08 Aug 2025 16:13:49 +0800
+
 cups (2.4.2-5deepin2) unstable; urgency=medium
 
   * Compatible with printer driver which runs on V20.

--- a/debian/patches/0017-Compatible-with-printer-driver-which-runs-on-V20.patch
+++ b/debian/patches/0017-Compatible-with-printer-driver-which-runs-on-V20.patch
@@ -1,17 +1,32 @@
+From 6fb8a6f40e09b068780ac7ecdf0b68886015096e Mon Sep 17 00:00:00 2001
 From: reddevillg <reddevillg@gmail.com>
 Date: Wed, 4 Dec 2024 15:28:30 +0800
 Subject: [PATCH] Compatible with printer driver which runs on V20
 
 If deepin-compatible-ctl exist, use it to run external process.
+
+Change-Id: Ifa668bb6dae6f6ff311dd2ec43a68737b8885516
 ---
- scheduler/process.c | 39 +++++++++++++++++++++++++++------------
- 1 file changed, 27 insertions(+), 12 deletions(-)
+ scheduler/process.c | 47 ++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 34 insertions(+), 13 deletions(-)
 
 diff --git a/scheduler/process.c b/scheduler/process.c
-index 1492e76..7c15db5 100644
+index 1492e767d..b2158d4e4 100644
 --- a/scheduler/process.c
 +++ b/scheduler/process.c
-@@ -555,30 +555,45 @@ cupsdStartProcess(
+@@ -478,7 +478,10 @@ cupsdStartProcess(
+ 		cups_exec[1024],	/* Path to "cups-exec" program */
+ 		user_str[16],		/* User string */
+ 		group_str[16],		/* Group string */
+-		nice_str[16];		/* FilterNice string */
++		nice_str[16],		/* FilterNice string */
++		filter_path[1024] = {0},
++		backend_path[1024] = {0};
++
+   uid_t		user;			/* Command UID */
+   cupsd_proc_t	*proc;			/* New process record */
+ #if USE_POSIX_SPAWN
+@@ -555,30 +558,48 @@ cupsdStartProcess(
    if (profile)
  #endif /* !USE_POSIX_SPAWN */
    {
@@ -22,17 +37,11 @@ index 1492e76..7c15db5 100644
      snprintf(user_str, sizeof(user_str), "%d", user);
      snprintf(group_str, sizeof(group_str), "%d", Group);
      snprintf(nice_str, sizeof(nice_str), "%d", FilterNice);
- 
--    real_argv[0] = cups_exec;
--    real_argv[1] = (char *)"-g";
--    real_argv[2] = group_str;
--    real_argv[3] = (char *)"-n";
--    real_argv[4] = nice_str;
--    real_argv[5] = (char *)"-u";
--    real_argv[6] = user_str;
--    real_argv[7] = profile ? profile : "none";
--    real_argv[8] = (char *)command;
-+    if (!stat("/usr/bin/deepin-compatible-ctl", &fileinfo))
++    snprintf(filter_path, sizeof(filter_path), "%s/filter/", ServerBin);
++    snprintf(backend_path, sizeof(backend_path), "%s/backend/", ServerBin);
++
++    if (!stat("/usr/bin/deepin-compatible-ctl", &fileinfo) &&
++         (strncmp(command, filter_path, strlen(filter_path)) == 0 || strncmp(command, backend_path, strlen(backend_path)) == 0))
 +    {
 +        real_argv[0] = (char *)"deepin-compatible-ctl";
 +        real_argv[1] = (char *)"app";
@@ -44,7 +53,16 @@ index 1492e76..7c15db5 100644
 +    } else {
 +        exec_path = cups_exec;
 +    }
-+
+ 
+-    real_argv[0] = cups_exec;
+-    real_argv[1] = (char *)"-g";
+-    real_argv[2] = group_str;
+-    real_argv[3] = (char *)"-n";
+-    real_argv[4] = nice_str;
+-    real_argv[5] = (char *)"-u";
+-    real_argv[6] = user_str;
+-    real_argv[7] = profile ? profile : "none";
+-    real_argv[8] = (char *)command;
 +    real_argv[idx + 0] = cups_exec;
 +    real_argv[idx + 1] = (char *)"-g";
 +    real_argv[idx + 2] = group_str;
@@ -70,5 +88,5 @@ index 1492e76..7c15db5 100644
  
    if (LogLevel == CUPSD_LOG_DEBUG2)
 -- 
-2.45.2
+2.20.1
 

--- a/scheduler/process.c
+++ b/scheduler/process.c
@@ -478,7 +478,10 @@ cupsdStartProcess(
 		cups_exec[1024],	/* Path to "cups-exec" program */
 		user_str[16],		/* User string */
 		group_str[16],		/* Group string */
-		nice_str[16];		/* FilterNice string */
+		nice_str[16],		/* FilterNice string */
+		filter_path[1024] = {0},
+		backend_path[1024] = {0};
+
   uid_t		user;			/* Command UID */
   cupsd_proc_t	*proc;			/* New process record */
 #if USE_POSIX_SPAWN
@@ -555,30 +558,48 @@ cupsdStartProcess(
   if (profile)
 #endif /* !USE_POSIX_SPAWN */
   {
+    struct stat fileinfo;
+    int idx = 0;
+
     snprintf(cups_exec, sizeof(cups_exec), "%s/daemon/cups-exec", ServerBin);
     snprintf(user_str, sizeof(user_str), "%d", user);
     snprintf(group_str, sizeof(group_str), "%d", Group);
     snprintf(nice_str, sizeof(nice_str), "%d", FilterNice);
+    snprintf(filter_path, sizeof(filter_path), "%s/filter/", ServerBin);
+    snprintf(backend_path, sizeof(backend_path), "%s/backend/", ServerBin);
 
-    real_argv[0] = cups_exec;
-    real_argv[1] = (char *)"-g";
-    real_argv[2] = group_str;
-    real_argv[3] = (char *)"-n";
-    real_argv[4] = nice_str;
-    real_argv[5] = (char *)"-u";
-    real_argv[6] = user_str;
-    real_argv[7] = profile ? profile : "none";
-    real_argv[8] = (char *)command;
+    if (!stat("/usr/bin/deepin-compatible-ctl", &fileinfo) &&
+         (strncmp(command, filter_path, strlen(filter_path)) == 0 || strncmp(command, backend_path, strlen(backend_path)) == 0))
+    {
+        real_argv[0] = (char *)"deepin-compatible-ctl";
+        real_argv[1] = (char *)"app";
+        real_argv[2] = (char *)"--ldrd";
+        real_argv[3] = (char *)"run";
+        real_argv[4] = (char *)"--";
+        idx = 5;
+        exec_path = "/usr/bin/deepin-compatible-ctl";
+    } else {
+        exec_path = cups_exec;
+    }
+
+    real_argv[idx + 0] = cups_exec;
+    real_argv[idx + 1] = (char *)"-g";
+    real_argv[idx + 2] = group_str;
+    real_argv[idx + 3] = (char *)"-n";
+    real_argv[idx + 4] = nice_str;
+    real_argv[idx + 5] = (char *)"-u";
+    real_argv[idx + 6] = user_str;
+    real_argv[idx + 7] = profile ? profile : "none";
+    real_argv[idx + 8] = (char *)command;
 
     for (i = 0;
          i < (int)(sizeof(real_argv) / sizeof(real_argv[0]) - 10) && argv[i];
 	 i ++)
-      real_argv[i + 9] = argv[i];
+      real_argv[idx + i + 9] = argv[i];
 
-    real_argv[i + 9] = NULL;
+    real_argv[idx + i + 9] = NULL;
 
     argv      = real_argv;
-    exec_path = cups_exec;
   }
 
   if (LogLevel == CUPSD_LOG_DEBUG2)

--- a/scheduler/process.c
+++ b/scheduler/process.c
@@ -478,10 +478,7 @@ cupsdStartProcess(
 		cups_exec[1024],	/* Path to "cups-exec" program */
 		user_str[16],		/* User string */
 		group_str[16],		/* Group string */
-		nice_str[16],		/* FilterNice string */
-		filter_path[1024] = {0},
-		backend_path[1024] = {0};
-
+		nice_str[16];		/* FilterNice string */
   uid_t		user;			/* Command UID */
   cupsd_proc_t	*proc;			/* New process record */
 #if USE_POSIX_SPAWN
@@ -558,48 +555,30 @@ cupsdStartProcess(
   if (profile)
 #endif /* !USE_POSIX_SPAWN */
   {
-    struct stat fileinfo;
-    int idx = 0;
-
     snprintf(cups_exec, sizeof(cups_exec), "%s/daemon/cups-exec", ServerBin);
     snprintf(user_str, sizeof(user_str), "%d", user);
     snprintf(group_str, sizeof(group_str), "%d", Group);
     snprintf(nice_str, sizeof(nice_str), "%d", FilterNice);
-    snprintf(filter_path, sizeof(filter_path), "%s/filter/", ServerBin);
-    snprintf(backend_path, sizeof(backend_path), "%s/backend/", ServerBin);
 
-    if (!stat("/usr/bin/deepin-compatible-ctl", &fileinfo) &&
-         (strncmp(command, filter_path, strlen(filter_path)) == 0 || strncmp(command, backend_path, strlen(backend_path)) == 0))
-    {
-        real_argv[0] = (char *)"deepin-compatible-ctl";
-        real_argv[1] = (char *)"app";
-        real_argv[2] = (char *)"--ldrd";
-        real_argv[3] = (char *)"run";
-        real_argv[4] = (char *)"--";
-        idx = 5;
-        exec_path = "/usr/bin/deepin-compatible-ctl";
-    } else {
-        exec_path = cups_exec;
-    }
-
-    real_argv[idx + 0] = cups_exec;
-    real_argv[idx + 1] = (char *)"-g";
-    real_argv[idx + 2] = group_str;
-    real_argv[idx + 3] = (char *)"-n";
-    real_argv[idx + 4] = nice_str;
-    real_argv[idx + 5] = (char *)"-u";
-    real_argv[idx + 6] = user_str;
-    real_argv[idx + 7] = profile ? profile : "none";
-    real_argv[idx + 8] = (char *)command;
+    real_argv[0] = cups_exec;
+    real_argv[1] = (char *)"-g";
+    real_argv[2] = group_str;
+    real_argv[3] = (char *)"-n";
+    real_argv[4] = nice_str;
+    real_argv[5] = (char *)"-u";
+    real_argv[6] = user_str;
+    real_argv[7] = profile ? profile : "none";
+    real_argv[8] = (char *)command;
 
     for (i = 0;
          i < (int)(sizeof(real_argv) / sizeof(real_argv[0]) - 10) && argv[i];
 	 i ++)
-      real_argv[idx + i + 9] = argv[i];
+      real_argv[i + 9] = argv[i];
 
-    real_argv[idx + i + 9] = NULL;
+    real_argv[i + 9] = NULL;
 
     argv      = real_argv;
+    exec_path = cups_exec;
   }
 
   if (LogLevel == CUPSD_LOG_DEBUG2)


### PR DESCRIPTION
https://pms.uniontech.com/bug-view-328133.html