### PR TITLE
chore(scheduler): add loongarch64 support for skipping deepin-compati…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cups (2.4.16-1deepin5) unstable; urgency=medium
+
+  * add loongarch64 support for skipping deepin-compatible-ctl
+
+ -- Heysion Yuan <heysion@deepin.com>  Wed, 29 Apr 2026 14:24:41 +0800
+
 cups (2.4.16-1deepin4) unstable; urgency=medium
 
   * Drop Prevides & Replaces libcups{,image}2t64.

--- a/debian/patches/0018-loongarch-skip-compatible-ldrd-mode.path
+++ b/debian/patches/0018-loongarch-skip-compatible-ldrd-mode.path
@@ -1,0 +1,22 @@
+Index: cups-deepin/scheduler/process.c
+===================================================================
+--- cups-deepin.orig/scheduler/process.c
++++ cups-deepin/scheduler/process.c
+@@ -571,6 +571,7 @@ cupsdStartProcess(
+     if (!stat("/usr/bin/deepin-compatible-ctl", &fileinfo) &&
+          (strncmp(command, filter_path, strlen(filter_path)) == 0 || strncmp(command, backend_path, strlen(backend_path)) == 0))
+     {
++#if defined(__loongarch64) || defined(__loongarch__)
+         real_argv[0] = (char *)"deepin-compatible-ctl";
+         real_argv[1] = (char *)"app";
+         real_argv[2] = (char *)"--ldrd";
+@@ -578,6 +579,9 @@ cupsdStartProcess(
+         real_argv[4] = (char *)"--";
+         idx = 5;
+         exec_path = "/usr/bin/deepin-compatible-ctl";
++#else
++        exec_path = cups_exec;
++#endif
+     } else {
+         exec_path = cups_exec;
+     }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@
 0005-feat-enable-lpd-to-encode-title.patch
 0007-Feat-add-audit-log-to-CUPS.patch
 0017-Compatible-with-printer-driver-which-runs-on-V20.patch
+0018-loongarch-skip-compatible-ldrd-mode.path


### PR DESCRIPTION
…ble-ctl

skip deepin-compatible-ctl on loongarch64 architecture to improve compatibility

Log: Added loongarch64 architecture support for skipping deepin-compatible-ctl to improve compatibility

chore(scheduler): 为龙芯架构添加跳过 deepin-compatible-ctl 的支持

在龙芯架构上跳过 deepin-compatible-ctl 以提高兼容性

Log: 为龙芯架构添加条件编译支持，使其在 loongarch64 架构下能正常工作